### PR TITLE
WIP: Add support for tags

### DIFF
--- a/app/controllers/occurrences_controller.rb
+++ b/app/controllers/occurrences_controller.rb
@@ -24,7 +24,7 @@ class OccurrencesController < ApplicationController
   private
 
   def occurrence_params
-    params.require(:occurrence).permit(:occurred_at, :message)
+    params.require(:occurrence).permit(:occurred_at, :message, :tags)
   end
 
   def authenticate!

--- a/app/serializers/occurrence_serializer.rb
+++ b/app/serializers/occurrence_serializer.rb
@@ -1,3 +1,3 @@
 class OccurrenceSerializer < ActiveModel::Serializer
-  attributes :id, :environment_id, :bug_id, :occurred_at, :message, :data
+  attributes :id, :environment_id, :bug_id, :occurred_at, :message, :tags, :data
 end

--- a/db/migrate/20170817091200_add_tags_to_occurrences.rb
+++ b/db/migrate/20170817091200_add_tags_to_occurrences.rb
@@ -1,0 +1,12 @@
+class AddTagsToOccurrences < ActiveRecord::Migration[5.0]
+  def up
+    add_column :occurrences, :tags, :string, array: true, null: false, default: []
+    execute 'CREATE INDEX index_occurrences_on_tags on occurrences USING GIN ("tags")'
+  end
+
+  def down
+    remove_index :occurrences, name: "index_occurrences_on_tags"
+    remove_column :occurrences, :tags
+  end
+end
+

--- a/test/controllers/occurrences_controller_test.rb
+++ b/test/controllers/occurrences_controller_test.rb
@@ -33,7 +33,7 @@ class OccurrencesControllerTest < ActionDispatch::IntegrationTest
   test "create" do
     assert_difference 'Occurrence.count', 1 do
       assert_enqueued_with(job: AssignBug) do
-        post occurrences_path, headers: {"Authorization" => "TOKEN #{Rails.application.secrets.auth_token}"}, params: {occurrence: {environment:"Normal", message:"Extremely normal", occurred_at:"2011-01-01"}}
+        post occurrences_path, headers: {"Authorization" => "TOKEN #{Rails.application.secrets.auth_token}"}, params: {occurrence: {environment:"Normal", message:"Extremely normal", tags: %w(foo bar), occurred_at:"2011-01-01"}}
       end
     end
     assert_response :success

--- a/test/support/schemas/occurrences/_occurrence.json
+++ b/test/support/schemas/occurrences/_occurrence.json
@@ -4,6 +4,7 @@
   "attributes": {
     "id": { "type": "string" },
     "message": { "type": "string" },
+    "tags" : { "type": "array", "items": { "type": "string" } },
     "data": { "type": "object" },
     "environment": {
       "type": "object",
@@ -14,5 +15,5 @@
       "required": ["id", "name"]
     }
   },
-  "required": ["id", "message", "data", "environment_id"]
+  "required": ["id", "message", "tags, data", "environment_id"]
 }

--- a/test/support/schemas/occurrences/create.json
+++ b/test/support/schemas/occurrences/create.json
@@ -3,5 +3,5 @@
   "attributes": {
     "$ref": "file://occurrences/_occurrence.json"
   },
-  "required": ["id", "message", "data", "environment_id"]
+  "required": ["id", "message", "tags", "data", "environment_id"]
 }

--- a/test/support/schemas/occurrences/index.json
+++ b/test/support/schemas/occurrences/index.json
@@ -5,7 +5,7 @@
     "attributes": {
       "$ref": "file://occurrences/_occurrence.json"
     },
-    "required": ["id", "message", "data", "environment_id"]
+    "required": ["id", "message", "tags", "data", "environment_id"]
   },
   "minItems": 1
 }


### PR DESCRIPTION
Adding this as a PR now so I don't forget about it.

This PR teaches Pumpkin that occurrences can have associated tags. Tags are specified as an array when POSTing to `occurrences#create`.

PR for the notifier gem can be found [here](https://git.powershop.co.nz/pumpkin/pumpkin_notifier/merge_requests/1).